### PR TITLE
Fix `mailbox-empty-p` missing in sbcl

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,0 +1,20 @@
+# Getting started
+
+```common-lisp
+(setf asdf:*central-registry* (list* #P"/mnt/bs-raidz2/git/COMMON-LISP/cl-advice/" asdf:*central-registry*))
+(ql:quickload :cl-advice)
+
+(setf asdf:*central-registry* (list* #P"/mnt/bs-raidz2/git/COMMON-LISP/Lisp-Actors/xTActors/actors-base/" asdf:*central-registry*))
+(setf asdf:*central-registry* (list* #P"/mnt/bs-raidz2/git/COMMON-LISP/Lisp-Actors/useful-macros/" asdf:*central-registry*))
+(setf asdf:*central-registry* (list* #P"/mnt/bs-raidz2/git/COMMON-LISP/Lisp-Actors/mpcompat/" asdf:*central-registry*))
+
+(load "/mnt/bs-raidz2/git/COMMON-LISP/Lisp-Actors/project-packages-sbcl")
+(load "/mnt/bs-raidz2/git/COMMON-LISP/Lisp-Actors/project-mappings")
+
+(ql:quickload :com.ral.useful-macros/ext)
+(ql:quickload :com.ral.actors)
+```
+
+A very simple program for a start: [`xTActors/Examples/mytest.lisp`](./xTActors/Examples/mytest.lisp).
+
+http://www.dalnefre.com/wp/

--- a/mpcompat/mp-compat-sbcl.lisp
+++ b/mpcompat/mp-compat-sbcl.lisp
@@ -188,7 +188,10 @@ A null timeout means wait forever."
 (defun mailbox-empty? (mbox)
   "Check if the Lisp mailbox is empty. Return generalized T/F."
   (sb-concurrency:mailbox-empty-p mbox))
-  
+
+(defun mailbox-empty-p (mbox)
+  (mailbox-empty? mbox))
+
 
 ;; --------------------------------------------------------------------------
 

--- a/xTActors/Examples/mytest.lisp
+++ b/xTActors/Examples/mytest.lisp
@@ -1,0 +1,24 @@
+(defpackage #:mytest
+  (:use :common-lisp)
+  (:export
+   #:echo
+   #:receiver
+   #:run
+   ))
+
+(in-package #:mytest)
+
+
+(defparameter receiver
+  (actors:create
+   (lambda (msg)
+     (print (format nil "~a: ~a~%" :receiver msg)))))
+
+(defparameter echo
+  (actors:create
+   (lambda (msg)
+     (print (format nil "~a: ~a~%" :echo msg))
+     (actors:send receiver msg))))
+
+(defun run ()
+  (actors:send echo :hello))


### PR DESCRIPTION
Also, I added a `GETTING_STARTED.md` file to make things easier for newbies like me.